### PR TITLE
Print number of BE solves, initialize SDC newton solve from previous iteration

### DIFF
--- a/backwards_euler.py
+++ b/backwards_euler.py
@@ -24,6 +24,8 @@ def backwards_euler(neq, t, tmax, dt_init, y_init, rhs, jac,
 
     y_new = np.zeros(neq)
 
+    total_be_solves = 0
+
     while time < tmax:
 
         converged = False
@@ -52,10 +54,12 @@ def backwards_euler(neq, t, tmax, dt_init, y_init, rhs, jac,
             err = np.linalg.norm(dy)/max(abs(y_new) + SMALL)
             niter += 1
 
+        total_be_solves += niter
+
         if time + dt > tmax:
             dt = tmax - time
 
         y_n[:] = y_new[:]
         time += dt
 
-    return y_n
+    return y_n, total_be_solves

--- a/sdc.py
+++ b/sdc.py
@@ -75,8 +75,12 @@ def sdc4(neq, t, tmax, dt_init, y_init, rhs, jac,
                 # define C = -R(y_old) + I/dt_m
                 C = -r_old[m][:] + (1/dt_m) * int_simps(m, dt_m, r_old[0], r_old[1], r_old[2])
 
-                # initial guess for time node m is m-1's solution
-                y_new[m][:] = y_new[m-1][:]
+                if kiter > 0:
+                    # initial guess for time node m is m's solution in the previous iteration
+                    y_new[m][:] = y_old[m][:]
+                else:
+                    # initial guess for time node m is m-1's solution
+                    y_new[m][:] = y_new[m-1][:]
 
                 # solve the nonlinear system for the updated y
                 err = 1.e30

--- a/sdc.py
+++ b/sdc.py
@@ -52,6 +52,8 @@ def sdc4(neq, t, tmax, dt_init, y_init, rhs, jac,
 
     dt_m = dt/(sdc_nodes-1)
 
+    total_be_solves = 0
+
     while time < tmax:
 
         # initially, we don't have the old solution at the m > 0 time
@@ -97,6 +99,8 @@ def sdc4(neq, t, tmax, dt_init, y_init, rhs, jac,
                     err = np.linalg.norm(dy)/max(abs(y_new[m]) + SMALL)
                     niter += 1
 
+                total_be_solves += niter
+
             # save the solution as the old solution for iteration
             for m in range(1, sdc_nodes):
                 y_old[m][:] = y_new[m][:]
@@ -109,7 +113,7 @@ def sdc4(neq, t, tmax, dt_init, y_init, rhs, jac,
         # set the starting point for the next timestep
         y_old[0][:] = y_new[sdc_nodes-1][:]
 
-    return y_new[sdc_nodes-1][:]
+    return y_new[sdc_nodes-1][:], total_be_solves
 
 
 def int_simps(m_end, dt_m, r0, r1, r2):
@@ -120,4 +124,3 @@ def int_simps(m_end, dt_m, r0, r1, r2):
     else:
         # integral from m = 1 to m = 2
         return dt_m/12.0 * (-r0 + 8*r1 + 5*r2)
-

--- a/test_be.py
+++ b/test_be.py
@@ -23,10 +23,12 @@ def doit():
 
     ts = [time]
 
+    total_be_solves = 0
+
     for tmax in tends:
 
-        y_new = be.backwards_euler(neq, time, tmax, tmax/10,
-                                   y_old, rhs, jac)
+        y_new, n_iters = be.backwards_euler(neq, time, tmax, tmax/10,
+                                            y_old, rhs, jac)
 
         time = tmax
         ts.append(time)
@@ -34,6 +36,8 @@ def doit():
             ys[n].append(y)
 
         y_old[:] = y_new[:]
+
+        total_be_solves += n_iters
 
     fig = plt.figure()
     ax = fig.add_subplot(111)
@@ -43,7 +47,9 @@ def doit():
 
     ax.set_xscale("log")
     ax.set_yscale("log")
-    fig.savefig("test.png")
+    fig.savefig("test_be.png")
+
+    print("Total no. BE solves: {}".format(total_be_solves))
 
 if __name__ == "__main__":
     doit()

--- a/test_sdc.py
+++ b/test_sdc.py
@@ -23,10 +23,12 @@ def doit():
 
     ts = [time]
 
+    total_be_solves = 0
+
     for tmax in tends:
 
-        y_new = sdc.sdc4(neq, time, tmax, tmax/10,
-                         y_old, rhs, jac)
+        y_new, num_be_solves = sdc.sdc4(neq, time, tmax, tmax/10,
+                                        y_old, rhs, jac)
 
         time = tmax
         ts.append(time)
@@ -34,6 +36,8 @@ def doit():
             ys[n].append(y)
 
         y_old[:] = y_new[:]
+
+        total_be_solves += num_be_solves
 
     fig = plt.figure()
     ax = fig.add_subplot(111)
@@ -43,7 +47,9 @@ def doit():
 
     ax.set_xscale("log")
     ax.set_yscale("log")
-    fig.savefig("test.png")
+    fig.savefig("test_sdc.png")
+
+    print("Total no. BE solves: {}".format(total_be_solves))
 
 if __name__ == "__main__":
     doit()


### PR DESCRIPTION
Counts the number of BE solves done with the BE and SDC tests and prints to terminal.

Also initializes the Newton iteration guess for SDC with the solution from the previous iteration, if available. This reduces the number of BE solves for the SDC test from ~2400 to ~1400.